### PR TITLE
fix: KLIEP + DANN + RegularTransfer for Tensorflow 2.3.1

### DIFF
--- a/adapt/base.py
+++ b/adapt/base.py
@@ -1351,7 +1351,8 @@ class BaseAdaptDeep(Model, BaseAdapt):
             loss = tf.reduce_mean(loss)
 
         # Run backwards pass.
-        self.optimizer.minimize(loss, self.trainable_variables, tape=tape)
+        gradients = tape.gradient(loss, self.trainable_variables)
+        self.optimizer.apply_gradients(zip(gradients, self.trainable_variables))
         self.compiled_metrics.update_state(ys, y_pred)
         # Collect metrics to return
         return_metrics = {}

--- a/adapt/feature_based/_coral.py
+++ b/adapt/feature_based/_coral.py
@@ -86,8 +86,7 @@ class CORAL(BaseAdaptEstimator):
     See also
     --------
     DeepCORAL
-    FE
-    mSDA
+    FA
 
     References
     ----------

--- a/adapt/feature_based/_dann.py
+++ b/adapt/feature_based/_dann.py
@@ -2,6 +2,7 @@
 DANN
 """
 
+import warnings
 import numpy as np
 import tensorflow as tf
 
@@ -104,11 +105,16 @@ and V. Lempitsky. "Domain-adversarial training of neural networks". In JMLR, 201
                  Xt=None,
                  yt=None,
                  lambda_=0.1,
-                 gamma=10.,
                  verbose=1,
                  copy=True,
                  random_state=None,
                  **params):
+        
+        if "gamma" in params:
+            warnings.warn("the `gamma` argument has been removed from DANN."
+                          " If you want to use the lambda update process, please"
+                          " use the `UpdateLambda` callback from adapt.utils")
+            params.pop("gamma")
         
         names = self._get_param_names()
         kwargs = {k: v for k, v in locals().items() if k in names}

--- a/adapt/feature_based/_fa.py
+++ b/adapt/feature_based/_fa.py
@@ -69,7 +69,6 @@ class FA(BaseAdaptEstimator):
     See also
     --------
     CORAL
-    mSDA
         
     Examples
     --------

--- a/adapt/feature_based/_fmmd.py
+++ b/adapt/feature_based/_fmmd.py
@@ -37,7 +37,7 @@ def _get_optim_function(Xs, Xt, kernel="linear", gamma=1., degree=2, coef=1.):
             Kxy = tf.matmul(tf.matmul(Xs, tf.linalg.diag(W**1)), tf.transpose(Xt))
 
             K = tf.concat((Kxx, Kxy), axis=1)
-            K = tf.concat((K, tf.concat((Kyy, tf.transpose(Kxy)), axis=1)), axis=0)
+            K = tf.concat((K, tf.concat((tf.transpose(Kxy), Kyy), axis=1)), axis=0)
 
             f = -tf.linalg.trace(tf.matmul(K, L))
             Df = tf.gradients(f, W)
@@ -53,7 +53,7 @@ def _get_optim_function(Xs, Xt, kernel="linear", gamma=1., degree=2, coef=1.):
             Kxy = pairwise_X(tf.matmul(Xs, tf.linalg.diag(W**1)), Xt)
 
             K = tf.concat((Kxx, Kxy), axis=1)
-            K = tf.concat((K, tf.concat((Kyy, tf.transpose(Kxy)), axis=1)), axis=0)
+            K = tf.concat((K, tf.concat((tf.transpose(Kxy), Kyy), axis=1)), axis=0)
             K = tf.exp(-gamma * K)
 
             f = -tf.linalg.trace(tf.matmul(K, L))
@@ -70,7 +70,7 @@ def _get_optim_function(Xs, Xt, kernel="linear", gamma=1., degree=2, coef=1.):
             Kxy = tf.matmul(tf.matmul(Xs, tf.linalg.diag(W**1)), tf.transpose(Xt))
 
             K = tf.concat((Kxx, Kxy), axis=1)
-            K = tf.concat((K, tf.concat((Kyy, tf.transpose(Kxy)), axis=1)), axis=0)
+            K = tf.concat((K, tf.concat((tf.transpose(Kxy), Kyy), axis=1)), axis=0)
             K = (gamma * K + coef)**degree
 
             f = -tf.linalg.trace(tf.matmul(K, L))
@@ -144,7 +144,7 @@ class fMMD(BaseAdaptEstimator):
     See also
     --------
     CORAL
-    FE
+    FA
     
     Examples
     --------
@@ -155,7 +155,7 @@ class fMMD(BaseAdaptEstimator):
     >>> model = fMMD(RidgeClassifier(), Xt=Xt, kernel="linear", random_state=0, verbose=0)
     >>> model.fit(Xs, ys)
     >>> model.score(Xt, yt)
-    0.45
+    0.92
     
     References
     ----------

--- a/adapt/instance_based/_kliep.py
+++ b/adapt/instance_based/_kliep.py
@@ -349,6 +349,7 @@ to covariateshift adaptation". In NIPS 2007
         b = b.reshape(-1, 1)
 
         alpha = np.ones((len(centers), 1)) / len(centers)
+        alpha = self._projection(alpha, b)
         previous_objective = -np.inf
         objective = np.mean(np.log(np.dot(A, alpha) + EPS))
         if self.verbose > 1:
@@ -360,10 +361,7 @@ to covariateshift adaptation". In NIPS 2007
             alpha += self.lr * np.dot(
                 np.transpose(A), 1./(np.dot(A, alpha) + EPS)
             )
-            alpha += b * ((((1-np.dot(np.transpose(b), alpha)) /
-                            (np.dot(np.transpose(b), b) + EPS))))
-            alpha = np.maximum(0, alpha)
-            alpha /= (np.dot(np.transpose(b), alpha) + EPS)
+            alpha = self._projection(alpha, b)
             objective = np.mean(np.log(np.dot(A, alpha) + EPS))
             k += 1
             
@@ -374,6 +372,14 @@ to covariateshift adaptation". In NIPS 2007
         return alpha, centers
 
 
+    def _projection(self, alpha, b):
+        alpha += b * ((((1-np.dot(np.transpose(b), alpha)) /
+                            (np.dot(np.transpose(b), b) + EPS))))
+        alpha = np.maximum(0, alpha)
+        alpha /= (np.dot(np.transpose(b), alpha) + EPS)
+        return alpha
+    
+    
     def _cross_val_jscore(self, Xs, Xt, kernel_params, cv):        
         split = int(len(Xt) / cv)
         cv_scores = []

--- a/tests/test_dann.py
+++ b/tests/test_dann.py
@@ -2,6 +2,7 @@
 Test functions for dann module.
 """
 
+import pytest
 import numpy as np
 import tensorflow as tf
 from tensorflow.keras import Sequential, Model
@@ -112,3 +113,9 @@ def test_optimizer_enc_disc():
     assert np.all(model.encoder_.get_weights()[0] == encoder.get_weights()[0])
     assert np.any(model.task_.get_weights()[0] != task.get_weights()[0])
     assert np.any(model.discriminator_.get_weights()[0] != disc.get_weights()[0])
+    
+    
+def test_warnings():
+    with pytest.warns() as record:
+        model = DANN(gamma=10.)
+    assert len(record) == 1


### PR DESCRIPTION
Fixes:

- KLIEP: Add initial projection
- DANN: remove `gamma`
- RegularTransfer: Change `minimize` in `train_step` from base.py by `apply_gradients`
- fMMD: fix kernel formulation